### PR TITLE
ci(release-please): prevent release please bump major

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
-      "include-v-in-tag": true
+      "include-v-in-tag": true,
+      "initial-version": "0.1.0"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
To prevent **release-please** from bumping to a major version, we need to set the `initial-version` to a value below `1.Y.Z.` Since `"bump-minor-pre-major": true` is already configured, this ensures that version increments remain within `0.X.Y` without automatically jumping to `1.0.0`.