### PR TITLE
chore(renovate): enable gomodTidy to tidy dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,11 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "config:recommended",
-        ":disableDependencyDashboard",
-        ":semanticCommits"
-    ],
-    "prHourlyLimit": 30,
-    "prConcurrentLimit": 100
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":disableDependencyDashboard",
+    ":semanticCommits"
+  ],
+  "prHourlyLimit": 30,
+  "prConcurrentLimit": 100,
+  "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
By default, renovate do not tidy dependencies [cf](https://docs.renovatebot.com/golang/#module-tidying)